### PR TITLE
Fix spelling intructionCoverage -> instructionCoverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It works only when the job or pipeline is reporting the coverage using `recordCo
 
 Following placeholder are
 
-- `intructionCoverage` : Display the instruction coverage percentage
+- `instructionCoverage` : Display the instruction coverage percentage
 - `branchCoverage` : Display the branch coverage percentage
 - `lineOfCode` : Display the total line of code
 - `numberOfTest` : Display the number of test
@@ -27,7 +27,7 @@ Following placeholder are
 
 For example a coverage badge can be displayed like this
 
-`<instanceUrl>/buildStatus/icon?job=job&subject=Coverage&status=${intructionCoverage}&color=${colorInstructionCoverage}`
+`<instanceUrl>/buildStatus/icon?job=job&subject=Coverage&status=${instructionCoverage}&color=${colorInstructionCoverage}`
 
 It will render a badge like this (example with 50% coverage)
 
@@ -80,9 +80,9 @@ pipeline {
         always {
             recordCoverage tools: [[pattern: 'target/site/jacoco/jacoco.xml']]
             echo "Coverage results embeddable build status build URL is:\n ${env.BUILD_URL}/badge/icon" +
-                 '?subject=Instruction+Coverage&status=${intructionCoverage}&color=${colorInstructionCoverage}'
+                 '?subject=Instruction+Coverage&status=${instructionCoverage}&color=${colorInstructionCoverage}'
             echo "Coverage results embeddable build status job URL is:\n ${env.JOB_URL}/badge/icon" +
-                 '?subject=Instruction+Coverage&status=${intructionCoverage}&color=${colorInstructionCoverage}'
+                 '?subject=Instruction+Coverage&status=${instructionCoverage}&color=${colorInstructionCoverage}'
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtension.java
+++ b/src/main/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtension.java
@@ -33,7 +33,7 @@ public class CoverageParameterResolverExtension implements ParameterResolverExte
                 }
 
                 // Get the values
-                Value intructionCoverage = action.getStatistics()
+                Value instructionCoverage = action.getStatistics()
                         .getValue(Baseline.PROJECT, Metric.INSTRUCTION)
                         .orElse(null);
                 Value branchCoverage = action.getStatistics()
@@ -49,13 +49,13 @@ public class CoverageParameterResolverExtension implements ParameterResolverExte
                 // Replace the parameters
                 parameter = parameter
                         .replace(
-                                "intructionCoverage",
-                                intructionCoverage != null ? FORMATTER.format(intructionCoverage) : parameter)
+                                "instructionCoverage",
+                                instructionCoverage != null ? FORMATTER.format(instructionCoverage) : parameter)
                         .replace(
                                 "branchCoverage", branchCoverage != null ? FORMATTER.format(branchCoverage) : parameter)
                         .replace("numberOfTest", numberOfTest != null ? FORMATTER.format(numberOfTest) : parameter)
                         .replace("lineOfCode", lineOfCode != null ? FORMATTER.format(lineOfCode) : parameter)
-                        .replace("colorInstructionCoverage", getColor(intructionCoverage))
+                        .replace("colorInstructionCoverage", getColor(instructionCoverage))
                         .replace("colorBranchCoverage", getColor(branchCoverage));
 
             } else if (actionable instanceof Job<?, ?>) {

--- a/src/test/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtensionTest.java
@@ -17,7 +17,7 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 class CoverageParameterResolverExtensionTest {
 
     @Test
-    void shouldResolveIntructionCoverage(JenkinsRule jenkins) throws Exception {
+    void shouldResolveInstructionCoverage(JenkinsRule jenkins) throws Exception {
         String pipeline = IOUtils.toString(
                 CoverageParameterResolverExtensionTest.class.getResourceAsStream("/pipelines/coverage.groovy"),
                 StandardCharsets.UTF_8);
@@ -29,7 +29,7 @@ class CoverageParameterResolverExtensionTest {
 
         // Coverages badges
         assertThat(new CoverageParameterResolverExtension().resolve(run1, "unknown"), is("unknown"));
-        assertThat(new CoverageParameterResolverExtension().resolve(run1, "intructionCoverage"), is("50.00%"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "instructionCoverage"), is("50.00%"));
         assertThat(new CoverageParameterResolverExtension().resolve(run1, "branchCoverage"), is("100.00%"));
         assertThat(new CoverageParameterResolverExtension().resolve(run1, "lineOfCode"), is("10"));
         assertThat(new CoverageParameterResolverExtension().resolve(run1, "numberOfTest"), is("5"));


### PR DESCRIPTION
## Fix spelling intructionCoverage -> instructionCoverage

Better to fix the spelling error before the first release.

### Testing done

Automated tests pass

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
