### PR TITLE
Display computing status when build is not successful or running

### DIFF
--- a/src/main/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtension.java
+++ b/src/main/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtension.java
@@ -6,6 +6,7 @@ import edu.hm.hafner.coverage.Value;
 import hudson.Extension;
 import hudson.model.Actionable;
 import hudson.model.Job;
+import hudson.model.Result;
 import hudson.model.Run;
 import io.jenkins.plugins.coverage.metrics.model.Baseline;
 import io.jenkins.plugins.coverage.metrics.model.ElementFormatter;
@@ -25,10 +26,25 @@ public class CoverageParameterResolverExtension implements ParameterResolverExte
         if (parameter != null) {
             if (actionable instanceof Run<?, ?>) {
                 Run<?, ?> run = (Run<?, ?>) actionable;
+                Result buildResult = run.getResult();
+                String buildStatus = (buildResult != null) ? buildResult.toString() : "COMPUTING";
 
                 // Get the action
                 CoverageBuildAction action = run.getAction(CoverageBuildAction.class);
+
                 if (action == null) {
+                    if (buildStatus.equals("SUCCESS")) {
+                        return parameter;
+                    }
+                    parameter = parameter
+                            .replace("instructionCoverage", buildStatus)
+                            .replace("branchCoverage", buildStatus)
+                            .replace("lineCoverage", buildStatus)
+                            .replace("numberOfTest", buildStatus)
+                            .replace("lineOfCode", buildStatus)
+                            .replace("colorInstructionCoverage", getBuildColor(buildStatus))
+                            .replace("colorBranchCoverage", getBuildColor(buildStatus))
+                            .replace("colorLineCoverage", getBuildColor(buildStatus));
                     return parameter;
                 }
 
@@ -89,5 +105,13 @@ public class CoverageParameterResolverExtension implements ParameterResolverExte
             }
         }
         return "green";
+    }
+
+    protected String getBuildColor(String status) {
+        if (status.equals("COMPUTING")) {
+            return "blue";
+        } else {
+            return "gray";
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtension.java
+++ b/src/main/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtension.java
@@ -27,13 +27,14 @@ public class CoverageParameterResolverExtension implements ParameterResolverExte
             if (actionable instanceof Run<?, ?>) {
                 Run<?, ?> run = (Run<?, ?>) actionable;
                 Result buildResult = run.getResult();
-                String buildStatus = (buildResult != null) ? buildResult.toString() : "COMPUTING";
+                String buildStatus =
+                        (buildResult != null) ? buildResult.toString().toLowerCase() : "computing";
 
                 // Get the action
                 CoverageBuildAction action = run.getAction(CoverageBuildAction.class);
 
                 if (action == null) {
-                    if (buildStatus.equals("SUCCESS")) {
+                    if (buildStatus.equals("success")) {
                         return parameter;
                     }
                     parameter = parameter
@@ -108,10 +109,12 @@ public class CoverageParameterResolverExtension implements ParameterResolverExte
     }
 
     protected String getBuildColor(String status) {
-        if (status.equals("COMPUTING")) {
-            return "blue";
-        } else {
+        if (status.equals("aborted")) {
             return "gray";
+        } else if (status.equals("failure")) {
+            return "red";
+        } else {
+            return "blue";
         }
     }
 }

--- a/src/test/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtensionTest.java
@@ -263,4 +263,11 @@ class CoverageParameterResolverExtensionTest {
                 new CoverageParameterResolverExtension().getColor(Coverage.valueOf(Metric.INSTRUCTION, "90/100")),
                 is("brightgreen"));
     }
+
+    @Test
+    void shouldGetBuildColor() {
+        assertThat(new CoverageParameterResolverExtension().getBuildColor("computing"), is("blue"));
+        assertThat(new CoverageParameterResolverExtension().getBuildColor("aborted"), is("gray"));
+        assertThat(new CoverageParameterResolverExtension().getBuildColor("failure"), is("red"));
+    }
 }

--- a/src/test/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtensionTest.java
@@ -73,7 +73,7 @@ class CoverageParameterResolverExtensionTest {
     }
 
     @Test
-    void shouldResolveInstructionCoverageForNonCoverageJob(JenkinsRule jenkins) throws Exception {
+    void shouldResolveInstructionCoverageForNonCoverageJobWithCompletion(JenkinsRule jenkins) throws Exception {
         String pipeline = IOUtils.toString(
                 CoverageParameterResolverExtensionTest.class.getResourceAsStream("/pipelines/no_coverage.groovy"),
                 StandardCharsets.UTF_8);
@@ -98,6 +98,27 @@ class CoverageParameterResolverExtensionTest {
         assertThat(
                 new CoverageParameterResolverExtension().resolve(run1, "colorBranchCoverage"),
                 is("colorBranchCoverage"));
+    }
+
+    @Test
+    void shouldResolveInstructionCoverageForNonCoverageJobWithoutCompletion(JenkinsRule jenkins) throws Exception {
+        String pipeline = IOUtils.toString(
+                CoverageParameterResolverExtensionTest.class.getResourceAsStream("/pipelines/no_coverage.groovy"),
+                StandardCharsets.UTF_8);
+        WorkflowJob workflowJob = jenkins.createProject(WorkflowJob.class);
+        workflowJob.setDefinition(new CpsFlowDefinition(pipeline, false));
+        WorkflowRun run1 = workflowJob.scheduleBuild2(0).waitForStart();
+        assertThat(run1.getResult(), equalTo(null));
+
+        // Coverages badges
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, null), nullValue());
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "unknown"), is("unknown"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "instructionCoverage"), is("COMPUTING"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "branchCoverage"), is("COMPUTING"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "lineOfCode"), is("COMPUTING"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "numberOfTest"), is("COMPUTING"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "colorInstructionCoverage"), is("blue"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "colorBranchCoverage"), is("blue"));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/coveragebadge/CoverageParameterResolverExtensionTest.java
@@ -98,6 +98,7 @@ class CoverageParameterResolverExtensionTest {
         assertThat(
                 new CoverageParameterResolverExtension().resolve(run1, "colorBranchCoverage"),
                 is("colorBranchCoverage"));
+        jenkins.waitForCompletion(run1);
     }
 
     @Test
@@ -113,12 +114,13 @@ class CoverageParameterResolverExtensionTest {
         // Coverages badges
         assertThat(new CoverageParameterResolverExtension().resolve(run1, null), nullValue());
         assertThat(new CoverageParameterResolverExtension().resolve(run1, "unknown"), is("unknown"));
-        assertThat(new CoverageParameterResolverExtension().resolve(run1, "instructionCoverage"), is("COMPUTING"));
-        assertThat(new CoverageParameterResolverExtension().resolve(run1, "branchCoverage"), is("COMPUTING"));
-        assertThat(new CoverageParameterResolverExtension().resolve(run1, "lineOfCode"), is("COMPUTING"));
-        assertThat(new CoverageParameterResolverExtension().resolve(run1, "numberOfTest"), is("COMPUTING"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "instructionCoverage"), is("computing"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "branchCoverage"), is("computing"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "lineOfCode"), is("computing"));
+        assertThat(new CoverageParameterResolverExtension().resolve(run1, "numberOfTest"), is("computing"));
         assertThat(new CoverageParameterResolverExtension().resolve(run1, "colorInstructionCoverage"), is("blue"));
         assertThat(new CoverageParameterResolverExtension().resolve(run1, "colorBranchCoverage"), is("blue"));
+        jenkins.waitForCompletion(run1);
     }
 
     @Test


### PR DESCRIPTION
Closes #16 

### Approach
Based on the Build Status, the badge status changes

Eg.
- if the build is running
![computing](https://github.com/jenkinsci/coverage-badges-extension-plugin/assets/107404972/94b134a4-3f1f-495e-9904-3cb1a338ecfe)
- If the build fails
![failure](https://github.com/jenkinsci/coverage-badges-extension-plugin/assets/107404972/900c0b9f-72b9-40e1-bb3a-184459270513)
- if the build aborted
![aborted](https://github.com/jenkinsci/coverage-badges-extension-plugin/assets/107404972/5bd272e9-2d38-4171-b238-57cb3e280e33)
- if the build is successfull
![coverage](https://github.com/jenkinsci/coverage-badges-extension-plugin/assets/107404972/7bf9b416-1d83-4514-8017-1ad3dff9a627)

Even there are cases where the build is successful but the **coverageBuildAction** fails which displays the parameter name
![same](https://github.com/jenkinsci/coverage-badges-extension-plugin/assets/107404972/4035e7aa-1115-4b4a-ba09-869ddb750136)


### Testing done
Added few test cases to check whether the changes work with build completion and without build completion

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

cc: @jonesbusy wdyt?